### PR TITLE
fix(fabric-1.21.4): Use the correct BlockState when generating models.

### DIFF
--- a/src/main/java/com/supermartijn642/movingelevators/model/CamoBakedModel.java
+++ b/src/main/java/com/supermartijn642/movingelevators/model/CamoBakedModel.java
@@ -51,7 +51,7 @@ public class CamoBakedModel implements BakedModel, FabricBakedModel {
             this.originalModel.emitBlockQuads(emitter, blockView, state, pos, randomSupplier, cullTest);
         else{
             BakedModel model = ClientUtils.getBlockRenderer().getBlockModel(camoState);
-            model.emitBlockQuads(emitter, blockView, state, pos, randomSupplier, cullTest);
+            model.emitBlockQuads(emitter, blockView, camoState, pos, randomSupplier, cullTest);
         }
     }
 


### PR DESCRIPTION
Fixes a crash when using mushroom blocks (or other multipart blocks) as a texture for elevator blocks.